### PR TITLE
Avoid implicit function declarations in the configure script

### DIFF
--- a/autoconf/hercules.m4
+++ b/autoconf/hercules.m4
@@ -291,6 +291,7 @@ AC_DEFUN([_HC_CHECK_NEED_GETOPT_WRAPPER],
                    Will the linker complain about duplicate
                    symbols for getopt? We'll soon find out!
                 */
+		int getopt(int, char *const[], const char *);
                 extern char *optarg;
                 extern int optind;
 
@@ -315,6 +316,7 @@ DUPGETOPT1
                    needs getopt. Will linker complain about
                    duplicate symbols for getopt? Let's see.
                 */
+		int getopt(int, char *const[], const char *);
                 extern char *optarg;
                 extern int optind;
                 extern int test2();
@@ -385,7 +387,7 @@ AC_DEFUN([HC_CHECK_NEED_GETOPT_OPTRESET],
         [hc_cv_need_getopt_optreset],
         [
             AC_TRY_LINK(
-                [],
+                [int getopt(int, char *const[], const char *);],
                 [
                     extern int optreset;
                     optreset=1;

--- a/configure.ac
+++ b/configure.ac
@@ -1168,6 +1168,7 @@ if test "$GCC" = "yes"; then
 
                             -g -O2 -fomit-frame-pointer
                     */
+		    #include <string.h>
 
                     int foo ()
                     {


### PR DESCRIPTION
For C99 compatibility.  Future compilers are likely not to accept implicit function declarations by default.