### PR TITLE
Fix autoconf CPU detection on Raspberry Pi

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1878,7 +1878,6 @@ if test "$hc_cv_auto_optimize" = "yes"; then
             hc_cv_is_intel_x86_arch=yes
             hc_cv_intel_cpu_type=k8
             ;;
-
         i386-yes|i486-yes|i586-yes|i686-yes|i786-yes)
 
             hc_cv_is_intel_x86_arch=yes
@@ -1904,6 +1903,11 @@ if test "$hc_cv_auto_optimize" = "yes"; then
             ;;
 
         xscale-yes|arm*-yes)
+
+            # this works around a problem with CPU detection on Cortex CPUs running in 32bit mode
+            if test $host_cpu = armv7l; then
+                host_cpu=$(LANG=en_US lscpu | grep 'Model name' | cut -d: -f2 | xargs | tr '[:upper:]' '[:lower:]')
+            fi
 
             hc_cv_is_intel_x86_arch=no
             hc_cv_optimization_flags="$hc_cv_optimization_flags -mcpu=$host_cpu -mtune=$host_cpu -frename-registers"


### PR DESCRIPTION
Autoconf falsely detects an "armv7l" CPU on Cortex machines like several Raspberry Pi 3 and 4 models, when they run in 32 bit mode (which they do in
current versions of Raspberry Pi OS (previously
called Raspbian).

This change works around the issue by correcting the host_cpu in configure.ac.

See also
- https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70210
- https://savannah.gnu.org/support/index.php?110360